### PR TITLE
REMOVE NPCs: Enable the Removal of All Non-Player Characters from the Table

### DIFF
--- a/JS/character.js
+++ b/JS/character.js
@@ -1,5 +1,6 @@
-function Character(name, dexMod) {
+function Character(name, dexMod, isPlayer) {
   this.name = name;
+  this.isPlayer = isPlayer;
   this.dexMod = dexMod;
   this.initiative = 0;
 

--- a/JS/global.js
+++ b/JS/global.js
@@ -1,14 +1,20 @@
 var table = [];
 var pageTableBody = document.getElementById("initiative").children[1];
 
-var c1 = new Character("Raja the Red", 4);
+var c1 = new Character("Raja the Red", 4, true);
 table.push(c1);
 
-var c2 = new Character("Tryst", 3);
+var c2 = new Character("Tryst", 3, true);
 table.push(c2);
 
-var c3 = new Character("Galanthus Titarius", -1);
+var c3 = new Character("Galanthus Titarius", -1, false);
 table.push(c3);
+
+var c4 = new Character("Crakule", 2, true);
+table.push(c4);
+
+var c5 = new Character("Solomon", 6, false);
+table.push(c5);
 
 // given a Character object, add it to table#initiative
 function addCharacterToTable(character) {
@@ -33,20 +39,37 @@ function addCharacterToTable(character) {
   pageTableBody.appendChild(newRow);
 }
 
+// wipe all rows from the table
+function clearTable() {
+  while (pageTableBody.firstChild) {
+    pageTableBody.removeChild(pageTableBody.firstChild);
+  }
+}
+
 // adds all characters to table#initiative as rows
 function populateTable() {
+  clearTable();
   for (var i = 0; i < table.length; i++) {
     addCharacterToTable(table[i]);
   }
 }
 
+// remove all non-player characters from the table
+function removeNPCs() {
+  players = [];
+  for (var i = 0; i < table.length; i++) {
+    var character = table[i];
+    if (character.isPlayer) {
+      players.push(character);
+    }
+  }
+  table = players;
+
+  populateTable();
+}
+
 // rolls initiative for all characters in table#initiative
 function rollForCharacters() {
-  // wipe all rows from the table
-  while (pageTableBody.firstChild) {
-    pageTableBody.removeChild(pageTableBody.firstChild);
-  }
-
   // roll initiative for each character in the table
   for (var i = 0; i < table.length; i++) {
     table[i].rollInitiative();

--- a/JS/global.js
+++ b/JS/global.js
@@ -56,7 +56,7 @@ function populateTable() {
 
 // remove all non-player characters from the table
 function removeNPCs() {
-  players = [];
+  var players = [];
   for (var i = 0; i < table.length; i++) {
     var character = table[i];
     if (character.isPlayer) {

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# Roll-Initiative (0.4.0)
-The initiative roller is a tool created to aid DMs in keeping track of combat. When the user clicks the **Roll** button, the tool rolls initiative for each character that has been added to the table. The characters are ordered from highest initiative roll to lowest; ties are broken with the flip of a coin.
+# Roll-Initiative (0.5.0)
+#### The initiative roller is a tool created to aid DMs in keeping track of combat. When the user clicks the
+
+**Roll**: The tool rolls initiative for each character that has been added to the table. Characters are ordered from highest initiative roll to lowest Any ties are broken with the flip of a coin.
+
+**Remove NPCs**: The tool allows removing all NPCs from the table without clearing it entirely. (*NOTE*: To wipe the table entirely, click the site name in the top left or refresh the page.)

--- a/index.html
+++ b/index.html
@@ -23,10 +23,11 @@
 
     <form class="ml-auto">
       <button class="btn btn-sm btn-info" type="button" onclick="rollForCharacters()">Roll</button>
-      <button class="btn btn-sm btn-danger" type="button">Clear NPCs</button>
+      <button class="btn btn-sm btn-danger" type="button" onclick="removeNPCs()">Clear NPCs</button>
     </form>
   </nav>
 
+  <!-- initiative table -->
   <div id="table-container" class="container-fluid">
     <table id="initiative" class="table table-bordered table-hover">
       <thead class="thead-light">

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
     <form class="ml-auto">
       <button class="btn btn-sm btn-info" type="button" onclick="rollForCharacters()">Roll</button>
-      <button class="btn btn-sm btn-danger" type="button">Reset</button>
+      <button class="btn btn-sm btn-danger" type="button">Clear NPCs</button>
     </form>
   </nav>
 


### PR DESCRIPTION
The **Reset** button is of little use if it clears the whole table. Wire it up to remove characters from the table when clicked, but only remove the NPCs.