### PR TITLE
ROW EDIT: Add Ability to Edit Certain Table Fields

### DIFF
--- a/JS/global.js
+++ b/JS/global.js
@@ -28,6 +28,9 @@ function addCharacterToTable(character) {
   // create the name column
   var nameCol = document.createElement("td");
   nameCol.appendChild(document.createTextNode(character.name));
+  nameCol.contentEditable = true;
+  nameCol.spellcheck = false;
+  nameCol.focusout = function() { saveName(this); };
   newRow.appendChild(nameCol);
 
   // create the dexterity modifier column
@@ -76,7 +79,7 @@ function removeRow(tr) {
 
 // remove all non-player characters from the table
 function removeNPCs() {
-  for (var i = table.length - 1; i >= 0; i--) {
+  for (var i = table.length-1; i >= 0; i--) {
     if (!table[i].isPlayer) {
       removeCharacter(i);
     }
@@ -102,4 +105,12 @@ function rollForCharacters() {
   });
 
   populateTable();
+}
+
+// saves a name edit to the Character in the table
+function saveName(td) {
+  var tdName = td.innerHTML;
+  var cIndex = td.parentNode.rowIndex-1;
+
+  table[cIndex].name = tdName;
 }

--- a/JS/global.js
+++ b/JS/global.js
@@ -36,6 +36,8 @@ function addCharacterToTable(character) {
   // create the dexterity modifier column
   var dexModCol = document.createElement("td");
   dexModCol.appendChild(document.createTextNode(character.dexMod));
+  dexModCol.contentEditable = true;
+  dexModCol.focusout = function() { saveDexMod(this); };
   newRow.appendChild(dexModCol);
 
   var rowActions = document.createElement("td");
@@ -105,6 +107,23 @@ function rollForCharacters() {
   });
 
   populateTable();
+}
+
+// saves a DEX modifier edit to the Character in the table.
+function saveDexMod(td) {
+  var tdDexMod = parseInt(td.innerHTML.replace("+", ""), 10);
+  if (isNaN(tdDexMod)) {
+    td.classList.add("bg-danger");
+    td.classList.add("text-white");
+    return;
+  } else {
+    td.classList.remove("bg-danger");
+    td.classList.remove("text-white");
+  }
+
+  var cIndex = td.parentNode.rowIndex-1;
+  table[cIndex].dexMod = tdDexMod;
+  td.innerHTML = tdDexMod;
 }
 
 // saves a name edit to the Character in the table


### PR DESCRIPTION
A character's name and DEX modifier need to be editable through the table itself. This is due to any number of reasons, chiefly that an error when initially adding the row should not be permanent.

As such, make the `name` and `dexMod` fields editable from the table. Since `name` is a simple string, input can be directly saved to the name field. However, since `dexMod` is used in calculations, edits must be validated as integers before saving.