### PR TITLE
AGNOSTICISM: Make Changes Such That the System Being Used Doesn't Matter

### DIFF
--- a/JS/character.js
+++ b/JS/character.js
@@ -1,7 +1,7 @@
-function Character(name, dexMod, isPlayer) {
+function Character(name, mod, isPlayer) {
   this.name = name;
   this.isPlayer = isPlayer;
-  this.dexMod = dexMod;
+  this.mod = mod;
   this.initiative = 0;
 
   // define methods
@@ -9,5 +9,5 @@ function Character(name, dexMod, isPlayer) {
 }
 
 function rollInitiative() {
-  this.initiative = rollDice(1, 20) + this.dexMod;
+  this.initiative = rollDice(1, 20) + this.mod;
 }

--- a/JS/global.js
+++ b/JS/global.js
@@ -34,11 +34,11 @@ function addCharacterToTable(character) {
   newRow.appendChild(nameCol);
 
   // create the dexterity modifier column
-  var dexModCol = document.createElement("td");
-  dexModCol.appendChild(document.createTextNode(character.dexMod));
-  dexModCol.contentEditable = true;
-  dexModCol.focusout = function() { saveDexMod(this); };
-  newRow.appendChild(dexModCol);
+  var modCol = document.createElement("td");
+  modCol.appendChild(document.createTextNode(character.mod));
+  modCol.contentEditable = true;
+  modCol.focusout = function() { saveMod(this); };
+  newRow.appendChild(modCol);
 
   var rowActions = document.createElement("td");
   // create the trash icon for deleting a row
@@ -110,9 +110,9 @@ function rollForCharacters() {
 }
 
 // saves a DEX modifier edit to the Character in the table.
-function saveDexMod(td) {
-  var tdDexMod = parseInt(td.innerHTML.replace("+", ""), 10);
-  if (isNaN(tdDexMod)) {
+function saveMod(td) {
+  var tdMod = parseInt(td.innerHTML.replace("+", ""), 10);
+  if (isNaN(tdMod)) {
     td.classList.add("bg-danger");
     td.classList.add("text-white");
     return;
@@ -122,8 +122,8 @@ function saveDexMod(td) {
   }
 
   var cIndex = td.parentNode.rowIndex-1;
-  table[cIndex].dexMod = tdDexMod;
-  td.innerHTML = tdDexMod;
+  table[cIndex].mod = tdMod;
+  td.innerHTML = tdMod;
 }
 
 // saves a name edit to the Character in the table

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Roll-Initiative (0.7.0)
-The initiative roller is a tool created to aid DMs in keeping track of combat. When the user clicks the
+The initiative roller is a system-agnostic tool created to aid GMs in keeping track of combat.
 
 ### Roll
 The tool rolls initiative for each character that has been added to the table. Characters are ordered from highest initiative roll to lowest Any ties are broken with the flip of a coin.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Roll-Initiative (0.7.0)
+# Roll-Initiative (0.7.1)
 The initiative roller is a system-agnostic tool created to aid GMs in keeping track of combat.
 
 ### Roll

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <tr>
           <th style="width:16.66%" scope="col">Initiative</th>
           <th style="width:58.35%" scope="col">Name</th>
-          <th style="width:16.66%" scope="col">DEX modifier</th>
+          <th style="width:16.66%" scope="col">Modifier</th>
           <th style="width:8.33%" scope="col"></th>
         </tr>
       </thead>


### PR DESCRIPTION
Currently, the modifier column is labeled **DEX modifier**. This implies that only GMs using systems that roll dexterity for initiative can utilize the tool. Really, as long as the system is d20 based, the initiative roller can be used.