### PR TITLE
ADD CHARACTER: Fully reset modal when dismissing it

### DIFF
--- a/JS/global.js
+++ b/JS/global.js
@@ -73,7 +73,7 @@ function createCharacterFromModal() {
 function resetModal() {
   document.getElementById("nameInput").value = "";
   document.getElementById("modifierInput").value = 0;
-  document.getElementById("modifierInput").classList.remove("active");
+  document.getElementById("isPlayerInput").classList.remove("active");
 }
 
 // adds all characters to table#initiative as rows

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Roll-Initiative (0.8.1)
+# Roll-Initiative (0.8.3)
 The initiative roller is a system-agnostic tool created to aid GMs in keeping track of combat.
 
 ### Roll


### PR DESCRIPTION
Fixes #16, which noted that the `isPlayer` input was not properly being reset when the modal was being dismissed.