### PR TITLE
Convert the Modifier's Placeholder Value to a Default Value

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             </div>
             <div class="form-group">
               <label for="modifierInput">Initiative Modifier</label>
-              <input type="number" class="form-control" id="modifierInput" placeholder="0">
+              <input type="number" class="form-control" id="modifierInput" value="0">
             </div>
             <div class="form-group btn-group-toggle" data-toggle="buttons">
               <label class="btn btn-secondary" id="isPlayerInput">

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             </div>
             <div class="form-group">
               <label for="modifierInput">Initiative Modifier</label>
-              <input type="number" class="form-control" id="modifierInput" value="0">
+              <input type="number" class="form-control" id="modifierInput" value="0" placeholder="0">
             </div>
             <div class="form-group btn-group-toggle" data-toggle="buttons">
               <label class="btn btn-secondary" id="isPlayerInput">


### PR DESCRIPTION
Making this conversion fixes #22. By making 0 the default value of the input, users can simply submit the modal and the 0 initiative will carry through. "Convert" isn't really the right word, since the placeholder value will remain. That, however, is only to make it clear to the user how the input's value will be treated in the case that they submit after deleting the input parameter (thanks to #23).