### PR TITLE
Edit Modifier Using Numeric Input

### DIFF
--- a/CSS/global.css
+++ b/CSS/global.css
@@ -17,6 +17,13 @@ table.table tr td:last-child {
   text-align: center;
 }
 
+/* remove spinner arrows for numeric inputs inside a table cell */
+td input[type=number]::-webkit-inner-spin-button,
+td input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 i.fas {
   cursor: pointer;
 }

--- a/JS/character.js
+++ b/JS/character.js
@@ -1,16 +1,19 @@
 class Character {
   constructor(name, mod, isPlayer) {
-    this.name = name;
     this.isPlayer = isPlayer;
-    this.mod = mod;
     this.initiative = 0;
+
+    this.setName(name);
+    this.setMod(mod);
   }
 
   setMod(mod) {
-    mod = parseInt(stripTags(mod).replace("+", ""), 10);
-    if (!isNaN(mod)) {
-      this.mod = mod;
+    mod = parseInt(mod, 10);
+    if (isNaN(mod)) {
+      this.mod = 0;
+      return;
     }
+    this.mod = mod;
   }
 
   setName(name) {

--- a/JS/global.js
+++ b/JS/global.js
@@ -48,7 +48,7 @@ function clearTableOnPage() {
 // create a new character from data in the modal
 function createCharacterFromModal() {
   var mName = document.getElementById("nameInput").value;
-  var mInitMod = parseInt(document.getElementById("modifierInput").value, 10) || 0;
+  var mInitMod = parseInt(document.getElementById("modifierInput").value, 10);
   var mIsPlayer = $("#isPlayerInput").hasClass("active");
 
   return new Character(mName, mInitMod, mIsPlayer);

--- a/JS/global.js
+++ b/JS/global.js
@@ -21,8 +21,7 @@ function addCharacterToPage(character) {
   // create the dexterity modifier column
   var modCol = document.createElement("td");
   modCol.appendChild(document.createTextNode(character.mod));
-  modCol.contentEditable = true;
-  modCol.focusout = function() { saveMod(this); };
+  modCol.onclick = function() { editModifierOnPage(this); };
   newRow.appendChild(modCol);
 
   var rowActions = document.createElement("td");
@@ -96,13 +95,32 @@ function rollForCharactersOnPage() {
   populatePage();
 }
 
-// saves a DEX modifier edit to the Character in the table.
-function saveMod(td) {
-  var cIndex = td.parentNode.rowIndex-1;
-  table.getCharacter(cIndex).setMod(td.innerHTML);
+function editModifierOnPage(td) {
+  // add rolling input to the td
+  let rolling = document.createElement("input");
+  rolling.id = "editMod"
+  rolling.type = "number";
+  rolling.placeholder = "0";
+  rolling.classList.add("form-control");
 
-  // set the dex modifier in the table to whatever it is on the character
-  td.innerHTML = table.getCharacter(cIndex).mod;
+  rolling.value = td.innerText;                     // set the value to the current modifier
+  td.innerHTML = "";                                // clear the cell's contents
+  rolling.focusout = function() { saveMod(this); }; // save on focusout
+  td.appendChild(rolling);
+
+  rolling.focus(); // focus on the rolling input
+}
+
+// saves a DEX modifier edit to the Character in the table.
+function saveMod(rollingInput) {
+  var cIndex = rollingInput.parentNode.parentNode.rowIndex-1;
+  console.log(cIndex);
+  console.log(table.getCharacter(cIndex));
+  console.log(rollingInput.value);
+  table.getCharacter(cIndex).setMod(rollingInput.value);
+
+  // set the dex modifier in the table to whatever it is on the character; remove rolling input
+  rollingInput.parentNode.innerHTML = table.getCharacter(cIndex).mod;
 }
 
 // saves a name edit to the Character in the table

--- a/JS/global.js
+++ b/JS/global.js
@@ -98,7 +98,7 @@ function rollForCharactersOnPage() {
 function editModifierOnPage(td) {
   // add rolling input to the td
   let rolling = document.createElement("input");
-  rolling.id = "editMod"
+  rolling.id = "editMod";
   rolling.type = "number";
   rolling.placeholder = "0";
   rolling.classList.add("form-control");

--- a/JS/global.js
+++ b/JS/global.js
@@ -114,9 +114,6 @@ function editModifierOnPage(td) {
 // saves a DEX modifier edit to the Character in the table.
 function saveMod(rollingInput) {
   var cIndex = rollingInput.parentNode.parentNode.rowIndex-1;
-  console.log(cIndex);
-  console.log(table.getCharacter(cIndex));
-  console.log(rollingInput.value);
   table.getCharacter(cIndex).setMod(rollingInput.value);
 
   // set the dex modifier in the table to whatever it is on the character; remove rolling input

--- a/JS/global.js
+++ b/JS/global.js
@@ -99,7 +99,7 @@ function rollForCharactersOnPage() {
 // saves a DEX modifier edit to the Character in the table.
 function saveMod(td) {
   var cIndex = td.parentNode.rowIndex-1;
-  var newMod = table.getCharacter(cIndex).setMod(td.innerHTML);
+  table.getCharacter(cIndex).setMod(td.innerHTML);
 
   // set the dex modifier in the table to whatever it is on the character
   td.innerHTML = table.getCharacter(cIndex).mod;


### PR DESCRIPTION
When an initiative modifier cell is clicked for editing, it should not be free entry. This is both for convenience of entry and limiting input to numbers.

Closes #19.